### PR TITLE
`request_region_record` fix for new release

### DIFF
--- a/src/components/Regions/IsmpRegionCard/index.tsx
+++ b/src/components/Regions/IsmpRegionCard/index.tsx
@@ -14,7 +14,7 @@ import en from 'javascript-time-ago/locale/en';
 import { useEffect, useState } from 'react';
 
 import { useSubmitExtrinsic } from '@/hooks/submitExtrinsic';
-import { timesliceToTimestamp } from '@/utils/functions';
+import { sendUnsignedTx, timesliceToTimestamp } from '@/utils/functions';
 import { makeResponse, makeTimeout, queryRequest } from '@/utils/ismp';
 
 import { useAccounts } from '@/contexts/account';
@@ -183,31 +183,24 @@ export const IsmpRegionCard = ({
       region.getRegionId()
     );
     setWorking(true);
-    submitExtrinsicWithFeeInfo(
-      regionxSymbol,
-      regionxDecimals,
-      request,
-      activeAccount.address,
-      activeSigner,
-      {
-        ready: () => toastInfo('Transaction was initiated'),
-        inBlock: () => toastInfo('In Block'),
-        finalized: () => {
-          /** */
-        },
-        success: () => {
-          toastSuccess('Transaction successful');
-          setWorking(false);
-          fetchRegions();
-        },
-        fail: () => {
-          toastError(`Failed to request region record`);
-        },
-        error: (e) => {
-          toastError(`Failed to request the region record. ${e}`);
-        },
-      }
-    );
+    sendUnsignedTx(request, {
+      ready: () => toastInfo('Transaction was initiated'),
+      inBlock: () => toastInfo('In Block'),
+      finalized: () => {
+        /** */
+      },
+      success: () => {
+        toastSuccess('Transaction successful');
+        setWorking(false);
+        fetchRegions();
+      },
+      fail: () => {
+        toastError(`Failed to request region record`);
+      },
+      error: (e) => {
+        toastError(`Failed to request the region record. ${e}`);
+      },
+    });
   };
 
   return (

--- a/src/components/Regions/IsmpRegionCard/index.tsx
+++ b/src/components/Regions/IsmpRegionCard/index.tsx
@@ -13,7 +13,6 @@ import TimeAgo from 'javascript-time-ago';
 import en from 'javascript-time-ago/locale/en';
 import { useEffect, useState } from 'react';
 
-import { useSubmitExtrinsic } from '@/hooks/submitExtrinsic';
 import { sendUnsignedTx, timesliceToTimestamp } from '@/utils/functions';
 import { makeResponse, makeTimeout, queryRequest } from '@/utils/ismp';
 
@@ -48,12 +47,7 @@ export const IsmpRegionCard = ({
     timeslicePeriod,
   } = useCoretimeApi();
   const {
-    state: {
-      api: regionxApi,
-      apiState: regionxApiState,
-      symbol: regionxSymbol,
-      decimals: regionxDecimals,
-    },
+    state: { api: regionxApi, apiState: regionxApiState },
   } = useRegionXApi();
   const {
     state: { activeAccount, activeSigner },
@@ -67,7 +61,6 @@ export const IsmpRegionCard = ({
 
   const { region, coreOccupancy, status } = regionMetadata;
   const { toastWarning, toastSuccess, toastInfo, toastError } = useToast();
-  const { submitExtrinsicWithFeeInfo } = useSubmitExtrinsic();
   const [working, setWorking] = useState(false);
 
   useEffect(() => {

--- a/src/models/common/consts.ts
+++ b/src/models/common/consts.ts
@@ -18,7 +18,7 @@ export const WEEK_IN_TIMESLICES = DAY_IN_TIMESLICES * 7;
 export const REGION_COLLECTION_ID = 42;
 
 export const CORETIME_PARA_ID = 1005;
-export const REGIONX_PARA_ID = 4479;
+export const REGIONX_PARA_ID = 2000;
 
 export const SAFE_XCM_VERSION = 3;
 

--- a/src/models/common/consts.ts
+++ b/src/models/common/consts.ts
@@ -18,7 +18,7 @@ export const WEEK_IN_TIMESLICES = DAY_IN_TIMESLICES * 7;
 export const REGION_COLLECTION_ID = 42;
 
 export const CORETIME_PARA_ID = 1005;
-export const REGIONX_PARA_ID = 2000;
+export const REGIONX_PARA_ID = 4479;
 
 export const SAFE_XCM_VERSION = 3;
 


### PR DESCRIPTION
In the new 2.0.0 Cocos release, the request_region_record extrinsic was made unsigned to improve the UX. This PR is a companion to that change.

https://github.com/RegionX-Labs/RegionX-Node/pull/235